### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@
  SPC f e h
 *** Workflow
 **** Navigation spacemacs layers/docs
-SPC f e h ->  SPC s l -> c-h c-f/c-v/f/v
+SPC h SPC ->  SPC s l -> c-h c-f/c-v/f/v
 **** Navigation elpa libraries
 SPC h L  -> SPC s l -> c-h c-f/c-v/f/v
 **** Navigation you own configuration


### PR DESCRIPTION
Warning (emacs): The 'SPC f e h' (or 'M-m f e h') binding is now deprecated and will be remove in the next release. Please use 'SPC h SPC' (or 'M-m h SPC') instead.